### PR TITLE
array_search() returns false upon an invalid step

### DIFF
--- a/WizardBehavior.php
+++ b/WizardBehavior.php
@@ -594,7 +594,7 @@ class WizardBehavior extends Behavior
         $index = array_search($step, $steps);
         $expectedStep = $this->expectedStep(); // NULL if wizard finished
 
-        if ($index == 0 || ($index >= 0 && ($this->forwardOnly
+        if ($index === 0 || ($index >= 0 && ($this->forwardOnly
             ? $expectedStep !== null &&
                 $index === array_search($expectedStep, $steps)
             : $expectedStep === null ||


### PR DESCRIPTION
Respond correctly to invalid steps.

You can test this by starting a wizard. Then changing the step parameter to something non existing. Without this patch, it will try to load a non existing step in the WizardStep event.
